### PR TITLE
version: add a API method that returns the server version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,18 @@ REST API Usage
 
 This is a basic description of the API exposed via REST. All the following subsections have as title the URI suffix they are available at.
 
+version/
+~~~~~~~~
+
+The most basic information given by the server is its own version. Usage example::
+
+   $ curl http://127.0.0.1:8000/version/
+
+Sample result::
+
+   {"version": "0.1.0"}
+
+
 jobstatuses/
 ~~~~~~~~~~~~
 

--- a/avocadoserver/urls.py
+++ b/avocadoserver/urls.py
@@ -31,6 +31,7 @@ tests_router.register(r'data', views.TestDataViewSet)
 
 urlpatterns = patterns(
     '',
+    url(r'^version/$', 'avocadoserver.views.version'),
     url(r'^', include(router.urls)),
     url(r'^', include(jobs_router.urls)),
     url(r'^', include(tests_router.urls)),

--- a/avocadoserver/views.py
+++ b/avocadoserver/views.py
@@ -13,10 +13,12 @@
 # Author: Cleber Rosa <cleber@redhat.com>
 
 from avocadoserver import models, serializers, permissions
+from avocadoserver.version import VERSION
 from django.http import Http404
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 from rest_framework.decorators import action, link
+from rest_framework.decorators import api_view, permission_classes
 
 
 class TestStatusViewSet(viewsets.ReadOnlyModelViewSet):
@@ -164,3 +166,12 @@ class TestDataViewSet(viewsets.ModelViewSet):
 
         test_data.save()
         return Response({'status': 'test data added'})
+
+
+@api_view(['GET'])
+@permission_classes((permissions.ReadOnlyPermission,))
+def version(request, format=None):
+    """
+    Returns the version of the running avocado server as JSON
+    """
+    return Response({'version': VERSION})

--- a/selftests/all/functional/avocadoserver/api.py
+++ b/selftests/all/functional/avocadoserver/api.py
@@ -34,6 +34,11 @@ class api(test.Test):
                                auth=(self.USERNAME,
                                      self.PASSWORD))
 
+    def test_version(self):
+        self.log.info('Testing that the server returns its version')
+        r = self.get("/version/")
+        self.assertEquals(r.status_code, 200)
+
     def test_jobs_empty(self):
         self.log.info('Testing that the server has no jobs')
         emtpy = {u'count': 0,
@@ -69,6 +74,7 @@ class api(test.Test):
         self.test_jobs_empty()
 
     def action(self):
+        self.test_version()
         self.test_jobs_empty()
         self.test_jobs_add()
         self.test_jobs_del()


### PR DESCRIPTION
The point of this API method, besides giving server end users the
information, is to allow client applications to adapt to server
versions, or more simply just require a given version and bail out
if that is not present.

Signed-off-by: Cleber Rosa crosa@redhat.com
