### PR TITLE
Port to Django Rest Framework 3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,26 +176,6 @@ Later, say that the job finishes running, the server may be updated by a client 
      http://localhost:9405/jobs/1/activities/
 
 
-jobs/<id>/testcount/
-~~~~~~~~~~~~~~~~~~~~
-
-This is a utility API that returns the number of tests that are part of the given job. Calling `/jobs/1/testcount/` GETs you::
-
-   {"testcount": 3}
-
-It's intended to be as simple as that.
-
-
-jobs/<id>/passrate/
-~~~~~~~~~~~~~~~~~~~
-
-This is another utility API that returns the passrate for the tests that are part of the given job. Calling `/jobs/1/passrate/` GETs you::
-
-   {"passrate": 66.67}
-
-This job has had two tests that PASSed and one that FAILed. The rate gets rounded to two decimal digits.
-
-
 jobs/<id>/tests/
 ~~~~~~~~~~~~~~~~
 

--- a/avocadoserver/models.py
+++ b/avocadoserver/models.py
@@ -68,7 +68,7 @@ class Job(models.Model):
     id = models.CharField(max_length=40, unique=True, blank=False, primary_key=True,
                           default=create_unique_job_id)
     name = models.CharField(max_length=255, unique=False, blank=True, null=True)
-    timeout = models.IntegerField(default=0)
+    timeout = models.PositiveIntegerField(default=0)
     priority = models.ForeignKey(JobPriority, null=True, blank=True)
     status = models.ForeignKey(JobStatus, null=True, blank=True)
 

--- a/avocadoserver/serializers.py
+++ b/avocadoserver/serializers.py
@@ -123,13 +123,6 @@ class JobSerializer(serializers.ModelSerializer):
     activities = JobActivitySerializer(many=True, read_only=True)
     tests = TestSerializer(many=True, read_only=True)
 
-    def validate_timeout(self, attrs, source):
-        '''
-        Correct negative timeouts, since they don't make sense
-        '''
-        attrs['timeout'] = max(attrs['timeout'], 0)
-        return attrs
-
     class Meta:
         model = models.Job
         fields = ('id', 'name', 'timeout', 'priority', 'status',

--- a/avocadoserver/serializers.py
+++ b/avocadoserver/serializers.py
@@ -17,56 +17,6 @@ import models
 from rest_framework import serializers
 
 
-#
-# Serializer Fields: deal with the individual fields that need special
-# behaviour when used on Serializer
-#
-
-class JobPrioritySerializerField(serializers.RelatedField):
-
-    def from_native(self, data):
-        try:
-            obj = models.JobPriority.objects.get(name=data)
-        except models.JobPriority.DoesNotExist:
-            obj = None
-        return obj
-
-    def to_native(self, value):
-        if isinstance(value, models.JobPriority):
-            return "%s" % value.name
-
-
-class JobStatusSerializerField(serializers.RelatedField):
-
-    def from_native(self, data):
-        try:
-            obj = models.JobStatus.objects.get(name=data)
-        except models.JobStatus.DoesNotExist:
-            obj = None
-        return obj
-
-    def to_native(self, value):
-        return "%s" % value.name
-
-
-class TestStatusSerializerField(serializers.RelatedField):
-
-    def from_native(self, data):
-        try:
-            obj = models.TestStatus.objects.get(name=data)
-        except models.TestStatus.DoesNotExist:
-            obj = None
-        return obj
-
-    def to_native(self, value):
-        return "%s" % value.name
-
-
-#
-# Serializers: deal wit the serialization of complete records. Can make use
-# of field serializers defined earlier
-#
-
 class JobStatusSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -90,7 +40,9 @@ class JobActivitySerializer(serializers.ModelSerializer):
 
 class TestActivitySerializer(serializers.ModelSerializer):
 
-    status = TestStatusSerializerField(read_only=False, required=False)
+    status = serializers.SlugRelatedField(
+        slug_field='name',
+        queryset=models.TestStatus.objects.all())
 
     class Meta:
         model = models.TestActivity
@@ -106,7 +58,9 @@ class TestDataSerializer(serializers.ModelSerializer):
 
 class TestSerializer(serializers.ModelSerializer):
 
-    status = TestStatusSerializerField(read_only=False, required=False)
+    status = serializers.SlugRelatedField(
+        slug_field='name',
+        queryset=models.TestStatus.objects.all())
 
     class Meta:
         model = models.Test
@@ -116,8 +70,13 @@ class TestSerializer(serializers.ModelSerializer):
 
 class JobSerializer(serializers.ModelSerializer):
 
-    priority = JobPrioritySerializerField(read_only=False, required=False)
-    status = JobStatusSerializerField(read_only=False, required=False)
+    priority = serializers.SlugRelatedField(
+        slug_field='name',
+        queryset=models.JobPriority.objects.all())
+
+    status = serializers.SlugRelatedField(
+        slug_field='name',
+        queryset=models.JobStatus.objects.all())
 
     # pylint: disable=E1123
     activities = JobActivitySerializer(many=True, read_only=True)

--- a/avocadoserver/views.py
+++ b/avocadoserver/views.py
@@ -17,7 +17,7 @@ from avocadoserver.version import VERSION
 from django.http import Http404
 from rest_framework import viewsets, status
 from rest_framework.response import Response
-from rest_framework.decorators import action, link
+from rest_framework.decorators import detail_route
 from rest_framework.decorators import api_view, permission_classes
 
 
@@ -37,8 +37,8 @@ class JobViewSet(viewsets.ModelViewSet):
     queryset = models.Job.objects.all()
     serializer_class = serializers.JobSerializer
 
-    @action(methods=['POST'])
-    def activity(self, request, pk=None):
+    @detail_route(methods=['post'])
+    def activity(self, request, *args, **kwargs):
         # pylint: disable=E1123
         job_activity = serializers.JobActivitySerializer(data=request.DATA)
         if job_activity.is_valid():
@@ -48,8 +48,8 @@ class JobViewSet(viewsets.ModelViewSet):
             return Response(job_activity.errors,
                             status=status.HTTP_400_BAD_REQUEST)
 
-    @action(methods=['POST'])
-    def test_activity(self, request, pk=None):
+    @detail_route(methods=['post'])
+    def test_activity(self, request, *args, **kwargs):
         # pylint: disable=E1123
         test_activity = serializers.TestActivitySerializer(data=request.DATA)
         if test_activity.is_valid():

--- a/avocadoserver/views.py
+++ b/avocadoserver/views.py
@@ -37,24 +37,6 @@ class JobViewSet(viewsets.ModelViewSet):
     queryset = models.Job.objects.all()
     serializer_class = serializers.JobSerializer
 
-    @link()
-    def testcount(self, request, pk):
-        test_count = models.Test.objects.filter(job_id=pk).count()
-        return Response({'testcount': test_count})
-
-    @link()
-    def passrate(self, request, pk):
-        test_count = models.Test.objects.filter(job_id=pk).count()
-        if test_count == 0:
-            return Response({'passrate': 0})
-
-        test_status_success = models.TestStatus.objects.get(name='PASS')
-        test_count_pass = models.Test.objects.filter(job_id=pk,
-                                                     status=test_status_success).count()
-
-        rate = round((float(test_count_pass) / float(test_count)) * 100, 2)
-        return Response({'passrate': rate})
-
     @action(methods=['POST'])
     def activity(self, request, pk=None):
         # pylint: disable=E1123

--- a/avocadoserver/views.py
+++ b/avocadoserver/views.py
@@ -21,6 +21,15 @@ from rest_framework.decorators import detail_route
 from rest_framework.decorators import api_view, permission_classes
 
 
+@api_view(['GET'])
+@permission_classes((permissions.ReadOnlyPermission,))
+def version(request, format=None):
+    """
+    Returns the version of the running avocado server as JSON
+    """
+    return Response({'version': VERSION})
+
+
 class TestStatusViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.TestStatus.objects.all()
     serializer_class = serializers.TestStatusSerializer
@@ -148,12 +157,3 @@ class TestDataViewSet(viewsets.ModelViewSet):
 
         test_data.save()
         return Response({'status': 'test data added'})
-
-
-@api_view(['GET'])
-@permission_classes((permissions.ReadOnlyPermission,))
-def version(request, format=None):
-    """
-    Returns the version of the running avocado server as JSON
-    """
-    return Response({'version': VERSION})

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ nosexcover==1.0.8
 tox==1.5.0
 virtualenv==1.9.1
 django==1.6.3
-djangorestframework==2.3.13
-drf-nested-routers==0.1.3
+djangorestframework==3.0.2
+drf-nested-routers==0.9.0
 gunicorn==18.0

--- a/selftests/all/functional/avocadoserver/api.py
+++ b/selftests/all/functional/avocadoserver/api.py
@@ -95,15 +95,17 @@ class api(test.Test):
     def test_jobs_add(self):
         self.log.info('Testing that a new job can be added')
         job = {u'id': u'a0a272a09d2edda895bae4d75f5aebfad6562fb0',
-               u'status': None,
+               u'status': 'NOSTATUS',
                u'activities': [],
                u'tests': [],
                u'name': u'foobar job',
-               u'priority': None,
+               u'priority': 'MEDIUM',
                u'timeout': 0}
 
         data = {"id": "a0a272a09d2edda895bae4d75f5aebfad6562fb0",
-                "name": "foobar job"}
+                "name": "foobar job",
+                "priority": "MEDIUM",
+                "status": "NOSTATUS"}
         r = self.post("/jobs/", data)
         self.assertEquals(r.json(), job)
 


### PR DESCRIPTION
This PR intends to make avocado-server functional with Django Rest Framework 3.0.

This is the definitive version of the patches on PR #11.