### PR TITLE
Nested router with API Root feature

### DIFF
--- a/avocadoserver/routers.py
+++ b/avocadoserver/routers.py
@@ -1,0 +1,29 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+from rest_framework import routers
+from rest_framework_nested import routers as nested_routers
+
+
+class DefaultRouter(nested_routers.SimpleRouter, routers.DefaultRouter):
+
+    """
+    Router that combines nested and API root capabilities
+
+    The first big chunk of functionality is the ability to nest multiple
+    routers, from `rest_framework_nested`, but these routers lack the
+    so called API Root feature, which the `rest_framework` has in its
+    `DefaultRouter`.
+    """
+    pass

--- a/avocadoserver/urls.py
+++ b/avocadoserver/urls.py
@@ -13,10 +13,11 @@
 # Author: Cleber Rosa <cleber@redhat.com>
 
 from django.conf.urls import patterns, include, url
-from rest_framework_nested import routers
+from avocadoserver import routers
+from rest_framework_nested import routers as nested
 import views
 
-router = routers.SimpleRouter()
+router = routers.DefaultRouter()
 router.register(r'jobstatuses', views.JobStatusViewSet)
 router.register(r'jobpriorities', views.JobPriorityViewSet)
 router.register(r'teststatuses', views.TestStatusViewSet)
@@ -27,11 +28,11 @@ router.register(r'linuxdistros', views.LinuxDistroViewSet)
 router.register(r'testenvironments', views.TestEnvironmentViewSet)
 router.register(r'jobs', views.JobViewSet)
 
-jobs_router = routers.NestedSimpleRouter(router, r'jobs', lookup='job')
+jobs_router = nested.NestedSimpleRouter(router, r'jobs', lookup='job')
 jobs_router.register(r'activities', views.JobActivityViewSet)
 jobs_router.register(r'tests', views.TestViewSet)
 
-tests_router = routers.NestedSimpleRouter(jobs_router, 'tests', lookup='test')
+tests_router = nested.NestedSimpleRouter(jobs_router, 'tests', lookup='test')
 tests_router.register(r'activities', views.TestActivityViewSet)
 tests_router.register(r'data', views.TestDataViewSet)
 

--- a/avocadoserver/version.py
+++ b/avocadoserver/version.py
@@ -16,7 +16,7 @@ __all__ = ['MAJOR', 'MINOR', 'RELEASE', 'VERSION']
 
 
 MAJOR = 0
-MINOR = 1
+MINOR = 2
 RELEASE = 0
 
 VERSION = "%s.%s.%s" % (MAJOR, MINOR, RELEASE)


### PR DESCRIPTION
We have been using the `drf-nested-router` extension, which lacks the feature to list the APIs available when request the root URL of a server. This mixes both routers to give us both features.

Also, with the addition of this significant feature, let's bump the version for the sake of clients.