### PR TITLE
selftests/all/unit/avocadoserver/models_unittest.py: support Python 2.6 ...

### DIFF
--- a/selftests/all/unit/avocadoserver/models_unittest.py
+++ b/selftests/all/unit/avocadoserver/models_unittest.py
@@ -74,11 +74,11 @@ class ModelsUnitests(unittest.TestCase):
 
     def test_job_unnamed(self):
         job = models.Job.objects.create(timeout=100)
-        self.assertIsNone(job.name)
+        self.assertEquals(job.name, None)
 
     def test_job_automatic_id(self):
         job = models.Job.objects.create()
-        self.assertIsNotNone(job.id)
+        self.assertNotEquals(job.id, None)
 
     def test_job_automatic_id_len_40(self):
         job = models.Job.objects.create()


### PR DESCRIPTION
...unittest assert

Since we want to make avocado-server also functional on Python 2.6 (RHEL 6 systems),
and we have a much smaller set of requirements than avocado itself, let's fix the
unittests by using simpler asserts, which are available on both Python 2.6 and
Python 2.7.

Signed-off-by: Cleber Rosa <crosa@redhat.com>