### PR TITLE
CORS support: add middleware that adds CORS headers to every response

### DIFF
--- a/avocadoserver/middleware.py
+++ b/avocadoserver/middleware.py
@@ -1,0 +1,24 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2015
+# Author: Cleber Rosa <cleber@redhat.com>
+
+
+class CorsHeadersMiddleware(object):
+
+    """
+    Simple Django middleware that adds very relaxed CORS headers
+    """
+
+    def process_response(self, request, response):
+        response['Access-Control-Allow-Origin'] = '*'
+        return response

--- a/avocadoserver/settings.py
+++ b/avocadoserver/settings.py
@@ -112,6 +112,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'avocadoserver.middleware.CorsHeadersMiddleware',
 )
 
 ROOT_URLCONF = 'avocadoserver.urls'


### PR DESCRIPTION
avocado-server is meant to be accessed by a number of clients, including
HTML+JS clients making AJAX requests. For obivous reasons, if the server
doesn't hint with the appropriate headers, the user agent (browser) will
refuse to process the response.

This is intentionally a very simple implementation, that gives the most
permissive access control setting in every single request. If we find
out that we need finer grained control, then we can implement that later.

Signed-off-by: Cleber Rosa <crosa@redhat.com>