### PR TITLE
Access Control: by default allow any kind of request to be fulfilled

### DIFF
--- a/avocadoserver/settings.py
+++ b/avocadoserver/settings.py
@@ -139,7 +139,7 @@ INSTALLED_APPS = (
 )
 
 REST_FRAMEWORK = {
-    'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAdminUser',),
+    'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.AllowAny',),
     'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',),
     'DEFAULT_PARSER_CLASSES': ('rest_framework.parsers.JSONParser',),
     'PAGINATE_BY': 10


### PR DESCRIPTION
Given the current state of avocado-server, let's not require any
authentication by default. As time allows it, we'll have a better
idea of what can be publicly served and what deserves some kind
of protection.

Signed-off-by: Cleber Rosa <crosa@redhat.com>