### PR TITLE
Remove unnecessary fields from model Job and other field updates

### DIFF
--- a/avocadoserver/fixtures/initial_data.json
+++ b/avocadoserver/fixtures/initial_data.json
@@ -75,30 +75,6 @@
 		"description": "Test generated warnings"}},
 
     {"pk": "1",
-     "model": "avocadoserver.jobpriority",
-     "fields": {"name": "LOW",
-		"description": "Low priority",
-		"priority": 1}},
-
-    {"pk": "2",
-     "model": "avocadoserver.jobpriority",
-     "fields": {"name": "MEDIUM",
-		"description": "Medium priority",
-		"priority": 2}},
-
-    {"pk": "3",
-     "model": "avocadoserver.jobpriority",
-     "fields": {"name": "HIGH",
-		"description": "High priority",
-		"priority": 3}},
-
-    {"pk": "4",
-     "model": "avocadoserver.jobpriority",
-     "fields": {"name": "URGENT",
-		"description": "Urgent priority",
-		"priority": 4}},
-
-    {"pk": "1",
      "model": "avocadoserver.linuxdistro",
      "fields": {"name": "unknown",
 		"version": "0",

--- a/avocadoserver/models.py
+++ b/avocadoserver/models.py
@@ -60,7 +60,7 @@ class Job(models.Model):
                           default=create_unique_job_id)
     description = models.CharField(max_length=255, unique=False, blank=True, null=True)
     time = models.DateTimeField(auto_now_add=True)
-    timeout = models.PositiveIntegerField(default=0)
+    elapsed_time = models.FloatField(default=0.0)
     status = models.ForeignKey(JobStatus, null=True, blank=True)
 
     def __unicode__(self):

--- a/avocadoserver/models.py
+++ b/avocadoserver/models.py
@@ -67,15 +67,15 @@ class TestStatus(ReadOnlyModel):
 class Job(models.Model):
     id = models.CharField(max_length=40, unique=True, blank=False, primary_key=True,
                           default=create_unique_job_id)
-    name = models.CharField(max_length=255, unique=False, blank=True, null=True)
+    description = models.CharField(max_length=255, unique=False, blank=True, null=True)
     time = models.DateTimeField(auto_now_add=True)
     timeout = models.PositiveIntegerField(default=0)
     priority = models.ForeignKey(JobPriority, null=True, blank=True)
     status = models.ForeignKey(JobStatus, null=True, blank=True)
 
     def __unicode__(self):
-        if self.name:
-            return "%s (%s)" % (self.id, self.name)
+        if self.description:
+            return "%s (%s)" % (self.id, self.description)
         else:
             return self.id
 

--- a/avocadoserver/models.py
+++ b/avocadoserver/models.py
@@ -68,6 +68,7 @@ class Job(models.Model):
     id = models.CharField(max_length=40, unique=True, blank=False, primary_key=True,
                           default=create_unique_job_id)
     name = models.CharField(max_length=255, unique=False, blank=True, null=True)
+    time = models.DateTimeField(auto_now_add=True)
     timeout = models.PositiveIntegerField(default=0)
     priority = models.ForeignKey(JobPriority, null=True, blank=True)
     status = models.ForeignKey(JobStatus, null=True, blank=True)
@@ -77,6 +78,9 @@ class Job(models.Model):
             return "%s (%s)" % (self.id, self.name)
         else:
             return self.id
+
+    class Meta:
+        ordering = ("time", )
 
 
 class JobActivity(models.Model):

--- a/avocadoserver/models.py
+++ b/avocadoserver/models.py
@@ -47,15 +47,6 @@ class JobStatus(ReadOnlyModel):
         return self.name
 
 
-class JobPriority(ReadOnlyModel):
-    name = models.CharField(max_length=255, unique=True, blank=False)
-    priority = models.SmallIntegerField(unique=True, blank=False)
-    description = models.TextField(blank=True)
-
-    def __unicode__(self):
-        return self.name
-
-
 class TestStatus(ReadOnlyModel):
     name = models.CharField(max_length=255, unique=True, blank=False)
     description = models.TextField(blank=True)
@@ -70,7 +61,6 @@ class Job(models.Model):
     description = models.CharField(max_length=255, unique=False, blank=True, null=True)
     time = models.DateTimeField(auto_now_add=True)
     timeout = models.PositiveIntegerField(default=0)
-    priority = models.ForeignKey(JobPriority, null=True, blank=True)
     status = models.ForeignKey(JobStatus, null=True, blank=True)
 
     def __unicode__(self):

--- a/avocadoserver/serializers.py
+++ b/avocadoserver/serializers.py
@@ -80,7 +80,7 @@ class JobSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Job
-        fields = ('id', 'description', 'time', 'timeout', 'status',
+        fields = ('id', 'description', 'time', 'elapsed_time', 'status',
                   'activities', 'tests')
 
 

--- a/avocadoserver/serializers.py
+++ b/avocadoserver/serializers.py
@@ -91,7 +91,7 @@ class JobSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Job
-        fields = ('id', 'name', 'timeout', 'priority', 'status',
+        fields = ('id', 'name', 'time', 'timeout', 'priority', 'status',
                   'activities', 'tests')
 
 

--- a/avocadoserver/serializers.py
+++ b/avocadoserver/serializers.py
@@ -24,13 +24,6 @@ class JobStatusSerializer(serializers.ModelSerializer):
         fields = ('name', 'description')
 
 
-class JobPrioritySerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = models.JobPriority
-        fields = ('name', 'description')
-
-
 class TestStatusSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -77,10 +70,6 @@ class TestSerializer(serializers.ModelSerializer):
 
 class JobSerializer(serializers.ModelSerializer):
 
-    priority = serializers.SlugRelatedField(
-        slug_field='name',
-        queryset=models.JobPriority.objects.all())
-
     status = serializers.SlugRelatedField(
         slug_field='name',
         queryset=models.JobStatus.objects.all())
@@ -91,7 +80,7 @@ class JobSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Job
-        fields = ('id', 'description', 'time', 'timeout', 'priority', 'status',
+        fields = ('id', 'description', 'time', 'timeout', 'status',
                   'activities', 'tests')
 
 

--- a/avocadoserver/serializers.py
+++ b/avocadoserver/serializers.py
@@ -91,7 +91,7 @@ class JobSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Job
-        fields = ('id', 'name', 'time', 'timeout', 'priority', 'status',
+        fields = ('id', 'description', 'time', 'timeout', 'priority', 'status',
                   'activities', 'tests')
 
 

--- a/avocadoserver/urls.py
+++ b/avocadoserver/urls.py
@@ -19,7 +19,6 @@ import views
 
 router = routers.DefaultRouter()
 router.register(r'jobstatuses', views.JobStatusViewSet)
-router.register(r'jobpriorities', views.JobPriorityViewSet)
 router.register(r'teststatuses', views.TestStatusViewSet)
 router.register(r'softwarecomponentkinds', views.SoftwareComponentKindViewSet)
 router.register(r'softwarecomponentarches', views.SoftwareComponentArchViewSet)

--- a/avocadoserver/views.py
+++ b/avocadoserver/views.py
@@ -42,12 +42,6 @@ class JobStatusViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.ReadOnlyPermission, )
 
 
-class JobPriorityViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = models.JobPriority.objects.all()
-    serializer_class = serializers.JobPrioritySerializer
-    permission_classes = (permissions.ReadOnlyPermission, )
-
-
 class JobViewSet(viewsets.ModelViewSet):
     queryset = models.Job.objects.all()
     serializer_class = serializers.JobSerializer

--- a/selftests/all/functional/avocadoserver/api.py
+++ b/selftests/all/functional/avocadoserver/api.py
@@ -193,7 +193,7 @@ class api(Test):
         job = {u'id': u'a0a272a09d2edda895bae4d75f5aebfad6562fb0',
                u'name': u'foobar job',
                u'status': 'NOSTATUS',
-               u'timeout': 0,
+               u'elapsed_time': 0.0,
                u'activities': [],
                u'tests': []}
 

--- a/selftests/all/functional/avocadoserver/api.py
+++ b/selftests/all/functional/avocadoserver/api.py
@@ -192,7 +192,6 @@ class api(Test):
         self.log.info('Testing that a new job can be added')
         job = {u'id': u'a0a272a09d2edda895bae4d75f5aebfad6562fb0',
                u'name': u'foobar job',
-               u'priority': 'MEDIUM',
                u'status': 'NOSTATUS',
                u'timeout': 0,
                u'activities': [],
@@ -200,7 +199,6 @@ class api(Test):
 
         data = {"id": "a0a272a09d2edda895bae4d75f5aebfad6562fb0",
                 "name": "foobar job",
-                "priority": "MEDIUM",
                 "status": "NOSTATUS"}
         r = self.post("/jobs/", data)
         self.assertEquals(r.json(), job)

--- a/selftests/all/unit/avocadoserver/models_unittest.py
+++ b/selftests/all/unit/avocadoserver/models_unittest.py
@@ -73,7 +73,7 @@ class ModelsUnitests(unittest.TestCase):
                          models.TestStatus.objects.count())
 
     def test_job_nodescription(self):
-        job = models.Job.objects.create(timeout=100)
+        job = models.Job.objects.create(elapsed_time=100.0)
         self.assertEquals(job.description, None)
 
     def test_job_automatic_id(self):
@@ -84,9 +84,9 @@ class ModelsUnitests(unittest.TestCase):
         job = models.Job.objects.create()
         self.assertEquals(len(job.id), 40)
 
-    def test_job_default_timeout(self):
+    def test_job_default_elapsed_time(self):
         job = models.Job.objects.create()
-        self.assertEquals(job.timeout, 0)
+        self.assertEquals(job.elapsed_time, 0.0)
 
     def test_job_add_same_id(self):
         '''

--- a/selftests/all/unit/avocadoserver/models_unittest.py
+++ b/selftests/all/unit/avocadoserver/models_unittest.py
@@ -72,9 +72,9 @@ class ModelsUnitests(unittest.TestCase):
         self.assertEqual(count,
                          models.TestStatus.objects.count())
 
-    def test_job_unnamed(self):
+    def test_job_nodescription(self):
         job = models.Job.objects.create(timeout=100)
-        self.assertEquals(job.name, None)
+        self.assertEquals(job.description, None)
 
     def test_job_automatic_id(self):
         job = models.Job.objects.create()
@@ -99,19 +99,19 @@ class ModelsUnitests(unittest.TestCase):
                           models.Job.objects.create,
                           id=job_1.id)
 
-    def test_job_add_same_name(self):
+    def test_job_add_same_description(self):
         '''
-        There are no restrictions on multiple jobs having the same name
+        There are no restrictions on multiple jobs having the same description
         '''
-        job_1 = models.Job.objects.create(name='same')
-        job_2 = models.Job.objects.create(name='same')
-        self.assertEquals(job_1.name, job_2.name)
+        job_1 = models.Job.objects.create(description='same')
+        job_2 = models.Job.objects.create(description='same')
+        self.assertEquals(job_1.description, job_2.description)
 
     def test_job_activity(self):
         '''
         Adds job activity to an existing job
         '''
-        job = models.Job.objects.create(name='job with activities')
+        job = models.Job.objects.create(description='job with activities')
         now = datetime.datetime.utcnow().replace(tzinfo=utc)
         job_setup = models.JobActivity.objects.create(job=job,
                                                       activity='setup',
@@ -125,7 +125,7 @@ class ModelsUnitests(unittest.TestCase):
         '''
         Attempts to add the same activity to the same job
         '''
-        job = models.Job.objects.create(name='job with activities')
+        job = models.Job.objects.create(description='job with activities')
         now = datetime.datetime.utcnow().replace(tzinfo=utc)
         job_setup = models.JobActivity.objects.create(job=job,
                                                       activity='setup',
@@ -135,7 +135,7 @@ class ModelsUnitests(unittest.TestCase):
                           job=job, activity='setup', time=now)
 
     def test_job_add_test_activity(self):
-        job = models.Job.objects.create(name='job with test activities')
+        job = models.Job.objects.create(description='job with test activities')
         test = models.Test.objects.create(job=job,
                                           tag='test.1')
         now = datetime.datetime.utcnow().replace(tzinfo=utc)
@@ -150,7 +150,7 @@ class ModelsUnitests(unittest.TestCase):
             time=now)
 
     def test_job_test_data(self):
-        job = models.Job.objects.create(name='job with test data')
+        job = models.Job.objects.create(description='job with test data')
         test = models.Test.objects.create(job=job,
                                           tag='test.2')
         now = datetime.datetime.utcnow().replace(tzinfo=utc)


### PR DESCRIPTION
In avocado-server, there are data models and fields that currently have no use, including (but possibly not limited to) job priorities. These can be added back if/when needed functionality requires it.

The changes for this PR are:

* Remove model `JobPriority`.
* Add field `time` (default to current time on the server). Order jobs by this field.
* Rename field `name` to `description`.
* Remove field `timeout`.
* Add field `elapsed_time`.

Related to PR #31 