### PR TITLE
avocadoserver.views: Enable ordering in Job and Test results.

### DIFF
--- a/avocadoserver/views.py
+++ b/avocadoserver/views.py
@@ -15,7 +15,7 @@
 from avocadoserver import models, serializers, permissions
 from avocadoserver.version import VERSION
 from django.http import Http404
-from rest_framework import viewsets, status
+from rest_framework import viewsets, status, filters
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route
 from rest_framework.decorators import api_view, permission_classes
@@ -45,6 +45,8 @@ class JobStatusViewSet(viewsets.ReadOnlyModelViewSet):
 class JobViewSet(viewsets.ModelViewSet):
     queryset = models.Job.objects.all()
     serializer_class = serializers.JobSerializer
+    filter_backends = (filters.OrderingFilter,)
+    ordering_fields = ('time', 'status', 'elapsed_time', 'description',)
 
     @detail_route(methods=['post'])
     def activity(self, request, *args, **kwargs):
@@ -91,6 +93,8 @@ class JobActivityViewSet(viewsets.ModelViewSet):
 class TestViewSet(viewsets.ModelViewSet):
     queryset = models.Test.objects.all()
     serializer_class = serializers.TestSerializer
+    filter_backends = (filters.OrderingFilter,)
+    ordering_fields = ('tag', 'status',)
 
     def create(self, request, job_pk):
         try:


### PR DESCRIPTION
When retrieving Job or Test results with query argument ordering,
you can order the result for one or more specific fields or
use the - prefix to reverse the order.

* Allowed fields to order in Jobs: time, status, elapsed_time, description.
* Allowed fields to order in Tests: tag, status.

For example, to retrieve the latest job results (ordered by time), use
the URL: `/jobs/?ordering=-time`.

See also: http://www.django-rest-framework.org/api-guide/filtering/#orderingfilter

Signed-off-by: Rudá Moura <rmoura@redhat.com>