### PR TITLE
Jobs and tests summary. [V2]

### DIFF
--- a/avocadoserver/views.py
+++ b/avocadoserver/views.py
@@ -108,6 +108,18 @@ class TestViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.OrderingFilter,)
     ordering_fields = ('tag', 'status',)
 
+    @list_route()
+    def summary(self, request, job_pk):
+        tests = models.Job.objects.get(pk=job_pk).tests
+        total = tests.count()
+        passed = tests.filter(status__name='PASS').count()
+        failed = tests.filter(Q(status__name='FAIL') |
+                              Q(status__name='ERROR')).count()
+        other = total - (passed + failed)
+        return Response({"passed": passed,
+                         "failed": failed,
+                         "other": other})
+
     def create(self, request, job_pk):
         try:
             job = models.Job.objects.get(pk=job_pk)


### PR DESCRIPTION
Changes from #36:

* Using Django filters in models, so we don't need to interact and count inside the for loop. Pointed by @clebergnu .
* The tests summary are now retrieve by a proper URL `/jobs/<job_id>/tests/summary/`, instead of defined attributes inside the tests results. So we avoid to calculate things when it wasn't needed.
* Remove `tests_total` and `tests_pass_rate` attributes. Rationale: You can calculate in client side, by using the values of summary or with the proper tests object.

In a nut-shell:

* `/jobs/summary/` => `{"passed":NUMBER, "failed":NUMBER, "other":NUMBER}`
* `/jobs/<job_id>/tests/summary/` => `{"passed":NUMBER, "failed":NUMBER, "other":NUMBER}`