### PR TITLE
requirements.txt: Use Sphinx 1.3 or greater.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-Sphinx==1.2b1
+# Avocado Server requirements
+Sphinx>=1.3
 coverage==3.6
 nose==1.3.0
 nosexcover==1.0.8


### PR DESCRIPTION
Use a up to date version of Sphinx, greater than 1.3 (1.3.1, 1.3.2, etc.),
otherwise the readthedocs site gives build problem like this:

	from sphinx import version_info
	ImportError: cannot import name version_info

Signed-off-by: Rudá Moura <rmoura@redhat.com>