### PR TITLE
Package improvements and security commonalities [v2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+PYTHON=$(shell which python)
+VERSION=$(shell $(PYTHON) $(CURDIR)/avocadoserver/version.py)
+
+RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
+RELEASE_SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1 $(VERSION))
+
+COMMIT=$(shell git log --pretty=format:'%H' -n 1)
+SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
+
+all:
+	@echo "make clean - Get rid of scratch and byte files"
+	@echo "make source - Create source package"
+	@echo "make srpm - Generate a source RPM package (.srpm)"
+	@echo "make rpm  - Generate binary RPMs"
+	@echo "Release related targets:"
+	@echo "make source-release - Create source package for the latest tagged release"
+	@echo "make srpm-release - Generate a source RPM package (.srpm) for the latest tagged release"
+	@echo "make rpm-release  - Generate binary RPMs for the latest tagged release"
+
+clean:
+	rm -fr SOURCES BUILD
+
+source: clean
+	if test ! -d SOURCES; then mkdir SOURCES; fi
+	git archive --prefix="avocado-server-$(COMMIT)/" -o "SOURCES/avocado-server-$(VERSION)-$(SHORT_COMMIT).tar.gz" HEAD
+
+srpm: source
+	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
+	mock --resultdir BUILD/SRPM -D "commit $(COMMIT)" --buildsrpm --spec avocado-server.spec --sources SOURCES
+
+rpm: srpm
+	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
+	mock --resultdir BUILD/RPM -D "commit $(COMMIT)" --rebuild BUILD/SRPM/avocado-server-$(VERSION)-*.src.rpm
+
+source-release: clean
+	if test ! -d SOURCES; then mkdir SOURCES; fi
+	git archive --prefix="avocado-server-$(RELEASE_COMMIT)/" -o "SOURCES/avocado-server-$(VERSION)-$(RELEASE_SHORT_COMMIT).tar.gz" $(VERSION)
+
+srpm-release: source-release
+	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
+	mock --resultdir BUILD/SRPM -D "commit $(RELEASE_COMMIT)" --buildsrpm --spec avocado-server.spec --sources SOURCES
+
+rpm-release: srpm-release
+	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
+	mock --resultdir BUILD/RPM -D "commit $(RELEASE_COMMIT)" --rebuild BUILD/SRPM/avocado-server-$(VERSION)-*.src.rpm

--- a/avocado-server.spec
+++ b/avocado-server.spec
@@ -20,6 +20,7 @@ Requires: python-django-rest-framework
 Requires: python-django-rest-framework-nestedrouters
 Requires: python-gunicorn
 Requires: systemd
+Requires(pre): shadow-utils
 
 %description
 avocado-server provides a REST based interface for applications to communicate
@@ -36,6 +37,13 @@ running on other machines, consolidates various job and test results, etc.
 %{__python2} setup.py install --root %{buildroot} --skip-build
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}
 install -p -m 644 data/systemd/%{modulename}.service $RPM_BUILD_ROOT%{_unitdir}/%{modulename}.service
+
+%pre
+getent group avocadoserver >/dev/null || groupadd -r avocadoserver
+getent passwd avocadoserver >/dev/null || \
+    useradd -r -g avocadoserver -d /dev/null -s /sbin/nologin \
+    -c "Avocado Test Result Server" avocadoserver
+exit 0
 
 %post
 %systemd_post %{modulename}.service

--- a/avocado-server.spec
+++ b/avocado-server.spec
@@ -3,6 +3,7 @@
  %define commit 0f1a6cefc485a64e495e1b4986b4fa0540333234
 %endif
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%define avocado_database_dir %{_sharedstatedir}/%{name}/database
 
 Summary: REST based interface for applications to communicate with the avocado test server
 Name: avocado-server
@@ -36,6 +37,7 @@ running on other machines, consolidates various job and test results, etc.
 %install
 %{__python2} setup.py install --root %{buildroot} --skip-build
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}
+mkdir -p $RPM_BUILD_ROOT%{avocado_database_dir}
 install -p -m 644 data/systemd/%{modulename}.service $RPM_BUILD_ROOT%{_unitdir}/%{modulename}.service
 
 %pre
@@ -60,6 +62,7 @@ exit 0
 %{python_sitelib}/%{modulename}-*.egg-info
 %{_bindir}/avocado-server-manage
 %{_unitdir}/%{modulename}.service
+%attr(770, avocadoserver, avocadoserver) %dir %{avocado_database_dir}
 
 %changelog
 * Mon Jun 29 2015 Cleber Rosa <cleber@redhat.com> - 0.25.0-2

--- a/avocado-server.spec
+++ b/avocado-server.spec
@@ -1,5 +1,7 @@
 %global modulename avocadoserver
-%global commit 9edb1469ec70a5553aedb613dfd9ffbea4e0f6c6
+%if ! 0%{?commit:1}
+ %define commit 0f1a6cefc485a64e495e1b4986b4fa0540333234
+%endif
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Summary: REST based interface for applications to communicate with the avocado test server

--- a/avocado-server.spec
+++ b/avocado-server.spec
@@ -7,7 +7,7 @@
 Summary: REST based interface for applications to communicate with the avocado test server
 Name: avocado-server
 Version: 0.25.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
@@ -16,8 +16,8 @@ Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-
 BuildRequires: python2-devel
 BuildRequires: systemd
 Requires: python
-Requires: python-django-restframework
-Requires: python-django-restframework-nestedrouters
+Requires: python-django-rest-framework
+Requires: python-django-rest-framework-nestedrouters
 Requires: python-gunicorn
 Requires: systemd
 
@@ -54,6 +54,9 @@ install -p -m 644 data/systemd/%{modulename}.service $RPM_BUILD_ROOT%{_unitdir}/
 %{_unitdir}/%{modulename}.service
 
 %changelog
+* Mon Jun 29 2015 Cleber Rosa <cleber@redhat.com> - 0.25.0-2
+- Update python-django-rest-framework package names
+
 * Tue Jun 16 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.25.0-1
 - Update to upstream version 0.25.0
 

--- a/avocado-server.spec
+++ b/avocado-server.spec
@@ -4,6 +4,7 @@
 %endif
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %define avocado_database_dir %{_sharedstatedir}/%{name}/database
+%define avocado_dashboard_dir %{_datadir}/%{name}/dashboard
 
 Summary: REST based interface for applications to communicate with the avocado test server
 Name: avocado-server
@@ -31,6 +32,8 @@ running on other machines, consolidates various job and test results, etc.
 
 %prep
 %setup -q -n %{name}-%{commit}
+mv dashboard/README.rst README-dashboard.rst
+mv dashboard/LICENSE LICENSE-dashboard
 
 %build
 %{__python2} setup.py build
@@ -39,6 +42,8 @@ running on other machines, consolidates various job and test results, etc.
 %{__python2} setup.py install --root %{buildroot} --skip-build
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}
 mkdir -p $RPM_BUILD_ROOT%{avocado_database_dir}
+mkdir -p $RPM_BUILD_ROOT%{avocado_dashboard_dir}
+cp -r dashboard/static/* $RPM_BUILD_ROOT%{avocado_dashboard_dir}
 install -p -m 644 data/systemd/%{modulename}.service $RPM_BUILD_ROOT%{_unitdir}/%{modulename}.service
 
 %pre
@@ -58,16 +63,18 @@ exit 0
 %systemd_postun
 
 %files
-%doc README.rst LICENSE
+%doc README.rst LICENSE README-dashboard.rst LICENSE-dashboard
 %{python_sitelib}/%{modulename}
 %{python_sitelib}/%{modulename}-*.egg-info
 %{_bindir}/avocado-server-manage
 %{_unitdir}/%{modulename}.service
 %attr(770, avocadoserver, avocadoserver) %dir %{avocado_database_dir}
+%{avocado_dashboard_dir}
 
 %changelog
 * Mon Jul  6 2015 Cleber Rosa <cleber@redhat.com> - 0.25.0-3
 - Add python-dj-static requirement
+- Add dashboard static files
 
 * Mon Jun 29 2015 Cleber Rosa <cleber@redhat.com> - 0.25.0-2
 - Update python-django-rest-framework package names

--- a/avocado-server.spec
+++ b/avocado-server.spec
@@ -8,7 +8,7 @@
 Summary: REST based interface for applications to communicate with the avocado test server
 Name: avocado-server
 Version: 0.25.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
@@ -19,6 +19,7 @@ BuildRequires: systemd
 Requires: python
 Requires: python-django-rest-framework
 Requires: python-django-rest-framework-nestedrouters
+Requires: python-dj-static
 Requires: python-gunicorn
 Requires: systemd
 Requires(pre): shadow-utils
@@ -65,6 +66,9 @@ exit 0
 %attr(770, avocadoserver, avocadoserver) %dir %{avocado_database_dir}
 
 %changelog
+* Mon Jul  6 2015 Cleber Rosa <cleber@redhat.com> - 0.25.0-3
+- Add python-dj-static requirement
+
 * Mon Jun 29 2015 Cleber Rosa <cleber@redhat.com> - 0.25.0-2
 - Update python-django-rest-framework package names
 

--- a/avocadoserver/version.py
+++ b/avocadoserver/version.py
@@ -20,3 +20,6 @@ MINOR = 25
 RELEASE = 0
 
 VERSION = "%s.%s.%s" % (MAJOR, MINOR, RELEASE)
+
+if __name__ == '__main__':
+    print VERSION

--- a/data/systemd/avocadoserver.service
+++ b/data/systemd/avocadoserver.service
@@ -7,7 +7,7 @@ User=root
 ; The working directory should be a private one, such as /var/lib/avocadoserver
 ; This will be changed when a user/group is introduced
 WorkingDirectory=/var/tmp
-ExecStart=/bin/gunicorn --chdir /var/tmp -u nobody -g nobody -p /var/run/avocadoserver.pid -b 0.0.0.0:9405 avocadoserver.wsgi:application
+ExecStart=/bin/gunicorn --chdir /var/tmp -u avocadoserver -g avocadoserver -p /var/run/avocadoserver.pid -b 0.0.0.0:9405 avocadoserver.wsgi:application
 ExecReload=/bin/kill -s HUP ${MAINPID}
 PrivateTmp=false
 

--- a/data/systemd/avocadoserver.service
+++ b/data/systemd/avocadoserver.service
@@ -4,10 +4,8 @@ After=network.target
 
 [Service]
 User=root
-; The working directory should be a private one, such as /var/lib/avocadoserver
-; This will be changed when a user/group is introduced
 WorkingDirectory=/var/tmp
-ExecStart=/bin/gunicorn --chdir /var/tmp -u avocadoserver -g avocadoserver -p /var/run/avocadoserver.pid -b 0.0.0.0:9405 avocadoserver.wsgi:application
+ExecStart=/bin/gunicorn --chdir /var/lib/avocado-server/database -u avocadoserver -g avocadoserver -p /var/run/avocadoserver.pid -b 0.0.0.0:9405 avocadoserver.wsgi:application
 ExecReload=/bin/kill -s HUP ${MAINPID}
 PrivateTmp=false
 


### PR DESCRIPTION
This PR brings three sets of closely related improvements:

* Building `avocado-server` RPM packages was rather manual, so this is fixed by adding a simple way to generate those packages from within the source tree (`$ make rpm`).
* `avocado-server` will now run under its own user and group, and has a private directory for its database.
* Dashboard packaged and available at `/dashboard/`.

To actually test this run `$ make rpm` and copy `BUILD/RPMS/avocado-server-*.rpm` to your target machine, then proceed with:

1) Enable the repo that hosts some package requirements with: `dnf copr enable cleber/avocado-server` to enable the repo
2) Install the previously built and copied package: `dnf install avocado-server-*.rpm`
3) Initiate the database with: `cd /var/lib/avocado-server/database && avocado-server-manage syncdb`
4) Set the correct ownership with: `chown avocadoserver.avocadoserver avocadoserver.sqlite`
5) Start the service with: `systemctl start avocadoserver.service`

Then poke the server, say with: `$ curl http://localhost:9405/teststatuses` or open `http://localhost:9405/dashboard` on a web browser.

---

Changes from v1:
* Added dashboard support