### PR TITLE
Allow Jobs to be referenced by shorter IDs

### DIFF
--- a/avocadoserver/models.py
+++ b/avocadoserver/models.py
@@ -20,6 +20,20 @@ from django.db import models
 from job_id import create_unique_job_id
 
 
+class JobManager(models.Manager):
+    def get(self, *args, **kwargs):
+        '''
+        Allows a job to be fetched by using a subset of the ID
+        '''
+        if 'id' in kwargs:
+            job_id = kwargs.pop('id')
+            kwargs['id__startswith'] = job_id
+        elif 'pk' in kwargs:
+            job_id = kwargs.pop('pk')
+            kwargs['pk__startswith'] = job_id
+        return super(JobManager, self).get(*args, **kwargs)
+
+
 class ReadOnlyModel(models.Model):
 
     """
@@ -62,6 +76,7 @@ class Job(models.Model):
     time = models.DateTimeField(auto_now_add=True)
     elapsed_time = models.FloatField(default=0.0)
     status = models.ForeignKey(JobStatus, null=True, blank=True)
+    objects = JobManager()
 
     def __unicode__(self):
         if self.description:

--- a/avocadoserver/settings.py
+++ b/avocadoserver/settings.py
@@ -142,7 +142,8 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.AllowAny',),
     'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',),
     'DEFAULT_PARSER_CLASSES': ('rest_framework.parsers.JSONParser',),
-    'PAGINATE_BY': 10
+    'PAGINATE_BY': 10,
+    'EXCEPTION_HANDLER': 'avocadoserver.views.exception_handler'
 }
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'

--- a/avocadoserver/tests.py
+++ b/avocadoserver/tests.py
@@ -75,6 +75,14 @@ class ModelsJobTests(django.test.TestCase):
         job = models.Job.objects.create()
         self.assertEquals(len(job.id), 40)
 
+    def test_get_short(self):
+        job_id = 'e727556485a5fe6965d5bf759a050555213c4c57'
+        job = models.Job.objects.create(id=job_id)
+        self.assertEquals(job.id, job_id)
+        for length in xrange(6, 40):
+            job = models.Job.objects.get(id=job_id[0:length])
+            self.assertEquals(job.id, job_id)
+
     def test_default_elapsed_time(self):
         job = models.Job.objects.create()
         self.assertEquals(job.elapsed_time, 0.0)

--- a/avocadoserver/views.py
+++ b/avocadoserver/views.py
@@ -13,15 +13,32 @@
 # Author: Cleber Rosa <cleber@redhat.com>
 
 from django.http import Http404
+from django.utils import six
 from django.db.models import Q
+from django.core.exceptions import MultipleObjectsReturned
+from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import viewsets, status, filters
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route, list_route
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.views import exception_handler as _exception_handler
 
 from avocadoserver import models, serializers, permissions
 from avocadoserver.version import VERSION
+
+
+class Http409(Exception):
+    pass
+
+
+def exception_handler(exc, context):
+    if isinstance(exc, Http409):
+        msg = _('Conflict.')
+        data = {'detail': six.text_type(msg)}
+        return Response(data, status=status.HTTP_409_CONFLICT)
+    else:
+        return _exception_handler(exc, context)
 
 
 @api_view(['GET'])
@@ -50,6 +67,16 @@ class JobViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.JobSerializer
     filter_backends = (filters.OrderingFilter,)
     ordering_fields = ('time', 'status', 'elapsed_time', 'description',)
+
+    def get_object(self):
+        try:
+            obj = models.Job.objects.get(pk=self.kwargs['pk'])
+            if obj is None:
+                raise Http404
+            else:
+                return obj
+        except MultipleObjectsReturned:
+            raise Http409
 
     @list_route()
     def summary(self, request):


### PR DESCRIPTION
Just like git, if a shorter (less characters) can uniquely identify a commit, this will let a shorter ID identify a given job.

Implements the card:

https://trello.com/c/xUKU087T/432-avocado-server-allow-rest-api-users-to-refer-jobs-by-its-short-sha1-instead-of-the-full-sha1