### PR TITLE
requirements: Update inspektor requirement to 0.1.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ djangorestframework==3.1.1
 drf-nested-routers==0.9.0
 gunicorn==18.0
 dj-static==0.0.6
-inspektor==0.1.15
+inspektor==0.1.16


### PR DESCRIPTION
Inspektor 0.1.15 has a bug (it doesn't require pep8,
so people trying to use it without pep8 are in for a
treat).

With the 0.1.16 release, that bug is fixed, so, let's update.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>