### PR TITLE
for python 2.7

### DIFF
--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -13,7 +13,9 @@ Setup
 
 First install the following dependencies (`pip install` is your friend):
 
-* ``django``
+* ``django`` 
+   Python 2.7 only supports django 1.11 please use:
+* ``django==1.11``
 * ``djangorestframework``
 * ``drf-nested-routers``
 


### PR DESCRIPTION
updated packages for python 2.7

django version 1.11 is latest supported by python 2.7 version.